### PR TITLE
Add support for using JSX (HTML) as confrm message

### DIFF
--- a/src/toastrEmitter.js
+++ b/src/toastrEmitter.js
@@ -17,7 +17,7 @@ export const toastrEmitter = {
   clean: () => emitter.emit('clean/toastr'),
   confirm: (...args) => {
     emitter.emit('toastr/confirm', {
-      message: args[0].toString(),
+      message: args[0],
       options: args[1] || {}
     });
   }


### PR DESCRIPTION
Remove toString()  method invocation of ‘message‘ parameter to support using JSX element (HTML content) directly. 
For example:
        let message = (
          <div>
            <h3}>Header Content</h3>
            <p>Some text...</p>
             <ul>
                   <li>Some item 1</li>
                   <li>Some item 2</li>
             <ul>
          </div>
        );
        toastr.confirm(message);
